### PR TITLE
Refactor, Generalise Client

### DIFF
--- a/scripts/onto.py
+++ b/scripts/onto.py
@@ -1,29 +1,62 @@
-from dataclasses import dataclass
 import time
-import os
-from typing import Callable, Literal, Optional
-import requests
+from dataclasses import dataclass
 from functools import wraps
+from typing import Callable, Literal, Optional
+
+import requests
+
+# Endpoint url (see https://ontology.onelondon.online/)
+_ONELONDON_OPENID_ENDPOINT = "https://ontology.onelondon.online/authorisation/auth/realms/terminology/protocol/openid-connect/token"
+
 
 def auto_refresh_token(func) -> Callable:
+    """
+    This function decorator checks if the access token has expired and refreshes it if necessary.
+    """
+
     @wraps(func)
     def wrap(self, *args, **kwargs):
         if time.time() > self._access_token_expire_time:
             print("[INFO] Access token expired. Auto-refreshing...")
             self._initialise_access_token()
         return func(self, *args, **kwargs)
+
     return wrap
 
-@dataclass
-class Endpoints:
-    authoring: str = 'https://ontology.onelondon.online/authoring/fhir/'
-    production: str = 'https://ontology.onelondon.online/production1/fhir/'
 
-class OneLondonTerminologyClient:
-    def __init__(self, client_id: str, client_secret: str, endpoint: str = Endpoints.authoring):
+@dataclass
+class OneLondonEndpoints:
+    authoring: str = "https://ontology.onelondon.online/authoring/fhir/"
+    production: str = "https://ontology.onelondon.online/production1/fhir/"
+
+
+class FHIRTerminologyClient:
+    """
+    A client for querying FHIR terminology services, such as the OneLondon terminology server.
+
+    Attributes:
+        client_id: client ID for the FHIR server
+        client_secret: client secret for the FHIR server
+        endpoint: the endpoint URL for the FHIR server (default: OneLondon authoring endpoint)
+        open_id_token_url: the URL for the OpenID token endpoint (default: OneLondon OpenID endpoint)
+
+    Methods:
+        retrieve_concept_codes_from_id: retrieves a list of concept codes from a value set ID
+        retrieve_concept_codes_from_desc: retrieves a list of concept codes from a value set URL or name
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        endpoint: str = OneLondonEndpoints.authoring,
+        open_id_token_url: str = _ONELONDON_OPENID_ENDPOINT,
+    ):
         self.client_id: str = client_id
         self.client_secret: str = client_secret
         self.endpoint: str = endpoint
+
+        self._open_id_token_url: str = open_id_token_url
         self._access_token: str
         self._access_token_expire_time: int
 
@@ -32,138 +65,125 @@ class OneLondonTerminologyClient:
     def _initialise_access_token(self):
         self._access_token, self._access_token_expire_time = self._get_access_token()
 
+    def _get_access_token(self) -> tuple[str, int]:
 
-    def _get_access_token(self):
-        # endpoint url (see https://ontology.onelondon.online/)
-        url = 'https://ontology.onelondon.online/authorisation/auth/realms/terminology/protocol/openid-connect/token'
-        
         # define request contents
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded'
-        }
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = {
-            'grant_type': 'client_credentials',
-            'client_id': self.client_id,
-            'client_secret': self.client_secret
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
         }
-        
+
         # Request access token
         try:
-            response = requests.post(url, headers=headers, data=data)
-        
+            response = requests.post(
+                self._open_id_token_url, headers=headers, data=data
+            )
+
             # check HTTP status code
             response.raise_for_status()
 
-            print(response.json())
-            
-            # get access token
-
+            # == Get access token ==
             # May fail if the response does not contain the expected keys
             # Likely as a result of incorrect client_id or client_secret
-            access_token = response.json()['access_token']
-            expiry_time = time.time() + 10 # response.json()['expires_in']
+            # (Don't need to try / except this - we want a failure!)
+            access_token: str = response.json()["access_token"]
+            expiry_time: int = round(time.time()) + response.json()["expires_in"]
 
             return access_token, expiry_time
-        
+
         except requests.RequestException as e:
             print(f"Unable to request: {e}")
-            return None
+            print("Check client_id or client_secret, or connectivity.")
+            raise ValueError("Failed to retrieve access token.")
 
     @auto_refresh_token
     def retrieve_concept_codes_from_id(self, value_set_id: str) -> list[Optional[str]]:
         """
         Retrieves a list of concept codes that are found in a value set
             value_set_id: id of the target FHIR value set
-        Returns a list of concept codes 
+        Returns a list of concept codes
         """
-        
+
         url = f"{self.endpoint}ValueSet/{value_set_id}"
-        
-        headers = {
-            "Authorization": f"Bearer {self._access_token}"
-        }
-        
+
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+
         response = requests.get(url, headers=headers)
-        
+
         # retrieve value set
         if response.status_code == 200:
             value_set = response.json()
-            
+
             # extract list of codes
-            concepts = value_set.get('compose', {}).get('include', [])[0].get('concept', [])
-            code_list = [item.get('code', 'no code listed') for item in concepts]
-            
+            concepts = (
+                value_set.get("compose", {}).get("include", [])[0].get("concept", [])
+            )
+            code_list = [item.get("code", "no code listed") for item in concepts]
+
             return code_list
         else:
             print(f"Failed to retrieve data: {response.status_code} - {response.text}")
             return []
 
     @auto_refresh_token
-    def retrieve_concept_codes_from_desc(self, query_value: str, query_type: Literal['url', 'name'] = 'url') -> list[Optional[str]]:
+    def retrieve_concept_codes_from_desc(
+        self, query_value: str, query_type: Literal["url", "name"] = "url"
+    ) -> list[Optional[str]]:
         """
-        Retrieves a list of concept codes that are found in a value set, via either a FHIR url or value set name 
+        Retrieves a list of concept codes that are found in a value set, via either a FHIR url or value set name
             query_type: either 'url' or 'name'
             query_value: corresponding FHIR url or name value
         Returns a list of concept codes
         """
 
         # Guard against invalid query types
-        if query_type not in ['url', 'name']:
+        if query_type not in ["url", "name"]:
             raise ValueError("Invalid query_type. Use 'url' or 'name'.")
-        
-        query_url = f'{self.endpoint}ValueSet/?{query_type}={query_value}'
 
-        headers = {
-            "Authorization": f"Bearer {self._access_token}"
-        }
+        query_url = f"{self.endpoint}ValueSet/?{query_type}={query_value}"
+
+        headers = {"Authorization": f"Bearer {self._access_token}"}
 
         # retrieve bundle metadata
         bundle_response = requests.get(query_url, headers=headers)
-        
+
         if bundle_response.status_code == 200:
             bundle = bundle_response.json()
 
             print(bundle)
-            
+
             # extract full url with id
             try:
-                full_url = bundle['entry'][0]['fullUrl']
-                
+                full_url = bundle["entry"][0]["fullUrl"]
+
                 # retrieve actual value set from full url
                 response = requests.get(full_url, headers=headers)
                 if response.status_code == 200:
                     value_set = response.json()
-                    
+
                     # extract list of codes
-                    concepts = value_set.get('compose', {}).get('include', [])[0].get('concept', [])
-                    code_list = [item.get('code', 'no code listed') for item in concepts]
-                    
+                    concepts = (
+                        value_set.get("compose", {})
+                        .get("include", [])[0]
+                        .get("concept", [])
+                    )
+                    code_list = [
+                        item.get("code", "no code listed") for item in concepts
+                    ]
+
                     return code_list
                 else:
-                    print(f"Failed to retrieve data: {response.status_code} - {response.text}")
+                    print(
+                        f"Failed to retrieve data: {response.status_code} - {response.text}"
+                    )
                     return []
             except IndexError:
                 print("No entries found in bundle.")
                 return []
         else:
-            print(f"Failed to retrieve bundle: {bundle_response.status_code} - {bundle_response.text}")
+            print(
+                f"Failed to retrieve bundle: {bundle_response.status_code} - {bundle_response.text}"
+            )
             return []
-        
-    def raw_query(self, query_url: str) -> dict:
-        """
-        Retrieves a raw query response from the server
-            query_url: url to query
-        Returns a dictionary of the response
-        """
-        
-        headers = {
-            "Authorization": f"Bearer {self._access_token}"
-        }
-        
-        response = requests.get(query_url, headers=headers)
-        
-        if response.status_code == 200:
-            return response.json()
-        else:
-            print(f"Failed to retrieve data: {response.status_code} - {response.text}")
-            return {}

--- a/scripts/onto.py
+++ b/scripts/onto.py
@@ -152,8 +152,6 @@ class FHIRTerminologyClient:
         if bundle_response.status_code == 200:
             bundle = bundle_response.json()
 
-            print(bundle)
-
             # extract full url with id
             try:
                 full_url = bundle["entry"][0]["fullUrl"]

--- a/scripts/onto.py
+++ b/scripts/onto.py
@@ -1,135 +1,169 @@
+from dataclasses import dataclass
+import time
 import os
+from typing import Callable, Literal, Optional
 import requests
-import json
+from functools import wraps
 
-def get_access_token():
-    """
-    Given a CLIENT_ID and CLIENT_SECRET (set as environmental variables)
-    Returns access token for session from OneLondon terminology server
-    """
-    client_id = os.getenv('CLIENT_ID')
-    client_secret = os.getenv('CLIENT_SECRET')
+def auto_refresh_token(func) -> Callable:
+    @wraps(func)
+    def wrap(self, *args, **kwargs):
+        if time.time() > self._access_token_expire_time:
+            print("[INFO] Access token expired. Auto-refreshing...")
+            self._initialise_access_token()
+        return func(self, *args, **kwargs)
+    return wrap
 
-    if not client_id or not client_secret:
-        raise ValueError("Client ID and/or Client Secret not set in environment variables.")
+@dataclass
+class Endpoints:
+    authoring: str = 'https://ontology.onelondon.online/authoring/fhir/'
+    production: str = 'https://ontology.onelondon.online/production1/fhir/'
 
-    # endpoint url (see https://ontology.onelondon.online/)
-    url = 'https://ontology.onelondon.online/authorisation/auth/realms/terminology/protocol/openid-connect/token'
-    
-    # define request contents
-    headers = {
-        'Content-Type': 'application/x-www-form-urlencoded'
-    }
-    data = {
-        'grant_type': 'client_credentials',
-        'client_id': client_id,
-        'client_secret': client_secret
-    }
-    
-    # POST request
-    try:
-        response = requests.post(url, headers=headers, data=data)
-    
-        # check HTTP status code
-        response.raise_for_status()
-    
-        # get access token
-        access_token = response.json().get('access_token')
-        if not access_token:
-            raise ValueError("Failed to find access token.")
+class OneLondonTerminologyClient:
+    def __init__(self, client_id: str, client_secret: str, endpoint: str = Endpoints.authoring):
+        self.client_id: str = client_id
+        self.client_secret: str = client_secret
+        self.endpoint: str = endpoint
+        self._access_token: str
+        self._access_token_expire_time: int
 
-        return access_token
-    
-    except requests.RequestException as e:
-        print(f"Unable to request: {e}")
-        return None
+        self._initialise_access_token()
 
-def retrieve_concept_codes_from_id(access_token, value_set_id, endpoint='authoring'):
-    """
-    Retrieves a list of concept codes that are found in a value set
-        access_token: OAuth2 token generated from a client ID and secret
-        value_set_id: id of the target FHIR value set
-        endpoint: default 'authoring', or 'production' (hardcoded for the OneLondon terminology server endpoints)
-    Returns a list of concept codes 
-    """
-    endpoints = {
-        'authoring': 'https://ontology.onelondon.online/authoring/fhir/',
-        'production': 'https://ontology.onelondon.online/production1/fhir/'
-    }
-    
-    url = f"{endpoints[endpoint]}ValueSet/{value_set_id}"
-    
-    headers = {
-        "Authorization": f"Bearer {access_token}"
-    }
-    
-    response = requests.get(url, headers=headers)
-    
-    # retrieve value set
-    if response.status_code == 200:
-        value_set = response.json()
+    def _initialise_access_token(self):
+        self._access_token, self._access_token_expire_time = self._get_access_token()
+
+
+    def _get_access_token(self):
+        # endpoint url (see https://ontology.onelondon.online/)
+        url = 'https://ontology.onelondon.online/authorisation/auth/realms/terminology/protocol/openid-connect/token'
         
-        # extract list of codes
-        concepts = value_set.get('compose', {}).get('include', [])[0].get('concept', [])
-        code_list = [item.get('code', 'no code listed') for item in concepts]
+        # define request contents
+        headers = {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        }
+        data = {
+            'grant_type': 'client_credentials',
+            'client_id': self.client_id,
+            'client_secret': self.client_secret
+        }
         
-        return code_list
-    else:
-        print(f"Failed to retrieve data: {response.status_code} - {response.text}")
-        return []
-
-def retrieve_concept_codes_from_desc(access_token, endpoint='authoring', query_type='url', query_value=''):
-    """
-    Retrieves a list of concept codes that are found in a value set, via either a FHIR url or value set name 
-        access_token: OAuth2 token generated from a client ID and secret
-        endpoint: default 'authoring', or 'production' (hardcoded for the OneLondon terminology server endpoints)
-        query_type: either 'url' or 'name'
-        query_value: corresponding FHIR url or name value
-    Returns a list of concept codes
-    """
-
-    endpoints = {
-        'authoring': 'https://ontology.onelondon.online/authoring/fhir/',
-        'production': 'https://ontology.onelondon.online/production1/fhir/'
-    }
-    
-    if query_type == 'url':
-        query_url = f"{endpoints[endpoint]}ValueSet/?url={query_value}"
-    elif query_type == 'name':
-        query_url = f"{endpoints[endpoint]}ValueSet/?name={query_value}"
-    else:
-        raise ValueError("Invalid query_type. Use 'url' or 'name'.")
-
-    headers = {
-        "Authorization": f"Bearer {access_token}"
-    }
-
-    # retrieve bundle metadata
-    bundle_response = requests.get(query_url, headers=headers)
-    
-    if bundle_response.status_code == 200:
-        bundle = bundle_response.json()
-        
-        # extract full url with id
+        # Request access token
         try:
-            full_url = bundle['entry'][0]['fullUrl']
+            response = requests.post(url, headers=headers, data=data)
+        
+            # check HTTP status code
+            response.raise_for_status()
+
+            print(response.json())
             
-            # retrieve actual value set from full url
-            response = requests.get(full_url, headers=headers)
-            if response.status_code == 200:
-                value_set = response.json()
-                
-                # extract list of codes
-                concepts = value_set.get('compose', {}).get('include', [])[0].get('concept', [])
-                code_list = [item.get('code', 'no code listed') for item in concepts]
-                
-                return code_list
-            else:
-                print(f"Failed to retrieve data: {response.status_code} - {response.text}")
-                return []
-        except IndexError:
-            print("No entries found in bundle.")
+            # get access token
+
+            # May fail if the response does not contain the expected keys
+            # Likely as a result of incorrect client_id or client_secret
+            access_token = response.json()['access_token']
+            expiry_time = time.time() + 10 # response.json()['expires_in']
+
+            return access_token, expiry_time
+        
+        except requests.RequestException as e:
+            print(f"Unable to request: {e}")
+            return None
+
+    @auto_refresh_token
+    def retrieve_concept_codes_from_id(self, value_set_id: str) -> list[Optional[str]]:
+        """
+        Retrieves a list of concept codes that are found in a value set
+            value_set_id: id of the target FHIR value set
+        Returns a list of concept codes 
+        """
+        
+        url = f"{self.endpoint}ValueSet/{value_set_id}"
+        
+        headers = {
+            "Authorization": f"Bearer {self._access_token}"
+        }
+        
+        response = requests.get(url, headers=headers)
+        
+        # retrieve value set
+        if response.status_code == 200:
+            value_set = response.json()
+            
+            # extract list of codes
+            concepts = value_set.get('compose', {}).get('include', [])[0].get('concept', [])
+            code_list = [item.get('code', 'no code listed') for item in concepts]
+            
+            return code_list
+        else:
+            print(f"Failed to retrieve data: {response.status_code} - {response.text}")
             return []
-    else:
-        print(f"Failed to retrieve bundle: {bundle_response.status_code} - {bundle_response.text}")
-        return []
+
+    @auto_refresh_token
+    def retrieve_concept_codes_from_desc(self, query_value: str, query_type: Literal['url', 'name'] = 'url') -> list[Optional[str]]:
+        """
+        Retrieves a list of concept codes that are found in a value set, via either a FHIR url or value set name 
+            query_type: either 'url' or 'name'
+            query_value: corresponding FHIR url or name value
+        Returns a list of concept codes
+        """
+
+        # Guard against invalid query types
+        if query_type not in ['url', 'name']:
+            raise ValueError("Invalid query_type. Use 'url' or 'name'.")
+        
+        query_url = f'{self.endpoint}ValueSet/?{query_type}={query_value}'
+
+        headers = {
+            "Authorization": f"Bearer {self._access_token}"
+        }
+
+        # retrieve bundle metadata
+        bundle_response = requests.get(query_url, headers=headers)
+        
+        if bundle_response.status_code == 200:
+            bundle = bundle_response.json()
+
+            print(bundle)
+            
+            # extract full url with id
+            try:
+                full_url = bundle['entry'][0]['fullUrl']
+                
+                # retrieve actual value set from full url
+                response = requests.get(full_url, headers=headers)
+                if response.status_code == 200:
+                    value_set = response.json()
+                    
+                    # extract list of codes
+                    concepts = value_set.get('compose', {}).get('include', [])[0].get('concept', [])
+                    code_list = [item.get('code', 'no code listed') for item in concepts]
+                    
+                    return code_list
+                else:
+                    print(f"Failed to retrieve data: {response.status_code} - {response.text}")
+                    return []
+            except IndexError:
+                print("No entries found in bundle.")
+                return []
+        else:
+            print(f"Failed to retrieve bundle: {bundle_response.status_code} - {bundle_response.text}")
+            return []
+        
+    def raw_query(self, query_url: str) -> dict:
+        """
+        Retrieves a raw query response from the server
+            query_url: url to query
+        Returns a dictionary of the response
+        """
+        
+        headers = {
+            "Authorization": f"Bearer {self._access_token}"
+        }
+        
+        response = requests.get(query_url, headers=headers)
+        
+        if response.status_code == 200:
+            return response.json()
+        else:
+            print(f"Failed to retrieve data: {response.status_code} - {response.text}")
+            return {}


### PR DESCRIPTION
Make FHIRTerminologyClient generalise so it can be used elsewhere (but FHIR / OpenID endpoints) can be used elsewhere.

Add auto token refresh feature

Add type hints in suitable places.

Ruff fmt / organise imports

-----

Things that can be cleaned up further: probs handle cases where the query failed (Raise exception) vs query returned 0 results but was valid.